### PR TITLE
add PKGBUILD file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+src/
+pkg/
+*.pkg.tar.zst

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,25 @@
+pkgname=darwin
+pkgver="$(date +%Y%m%d)"
+pkgrel=1
+pkgdesc='Darwin - a font family optimized for academic, scientific, and book writing'
+url='https://darwintypeface.com/'
+arch=('i686' 'x86_64')
+license=('OFL-1.1')
+depends=()
+makedepends=()
+
+provides=('darwin')
+
+build() {
+  cd "${srcdir}"
+  rm -fr build; cp -a "${startdir}"/output build
+  cp "${startdir}"/LICENSE.md build
+}
+
+package() {
+  cd "${srcdir}/build"
+  install -Dm644 'DarwinSerif-Regular.otf' "${pkgdir}/usr/share/fonts/OTF/DarwinSerif-Regular.otf"
+  install -Dm644 'DarwinSerif-Regular.ttf' "${pkgdir}/usr/share/fonts/TTF/DarwinSerif-Regular.ttf"
+  install -Dm644 'LICENSE.md' "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE.md"
+}
+

--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ If you'd like to support the development of this project, there are several ways
 ## Build
 I'm currently working on migrating to Glyphs, and plan to implement a build process for Darwin using [`fontmake`](https://github.com/googlefonts/fontmake). For now, see the [`output`](https://github.com/topological-modular-forms/Darwin-Typeface/tree/main/output) folder for OTF and TTF font files.
 
+## Installation
+Copying the output/ files in the relevant directories of your computer should be sufficient.
+
+Alternatively, here are instructions for specific systems:
+- Archlinux: create the package by running `makepkg` and install it with `pacman -U`
+
 ## Why “Darwin”?
 The Darwin typeface is named after my dog, Darwin, who was in turn named so by my mother, after Charles Darwin:
 


### PR DESCRIPTION
Add a PKGBUILD file. On an Archlinux system it allows the following commands to install the font as a normal package (meaning it can be updated, removed, etc. using the package manager).

```
makepkg
pacman -U <name-of-the-package-file>.pkg.tar.zst
```

1. It would be nice if someone else with a similar system tried to run the commands to check that it works not just on my machine.
2. The file names for the installed files are hard-coded. It'd be better to loop over them in some way but I'm not sure what's the most portable way to do so.